### PR TITLE
Windows now reset their TopMost status if the program is closed and are not stuck on top

### DIFF
--- a/TopMostFriend/Program.cs
+++ b/TopMostFriend/Program.cs
@@ -67,7 +67,7 @@ namespace TopMostFriend {
             string cliToggle = args.FirstOrDefault(x => x.StartsWith(@"--hwnd="));
             if(!string.IsNullOrEmpty(cliToggle) && int.TryParse(cliToggle.Substring(7), out int cliToggleHWnd)) {
                 WindowInfo cliWindow = new WindowInfo(cliToggleHWnd);
-                if(!cliWindow.ToggleTopMost())
+                if(!cliWindow.ToggleTopMost(true))
                     TopMostFailed(cliWindow);
             }
 
@@ -125,7 +125,7 @@ namespace TopMostFriend {
             }
 
             OriginalIcon = Icon.ExtractAssociatedIcon(Application.ExecutablePath);
-
+            
             CtxMenu = new ContextMenuStrip {
                 BackgroundImage = backgroundImage,
                 BackgroundImageLayout = backgroundLayout,
@@ -190,6 +190,8 @@ namespace TopMostFriend {
             HotKeys?.Dispose();
             SysIcon?.Dispose();
             GlobalMutex.ReleaseMutex();
+            // Making sure no window is left with the TopMost attribute active after closing the app
+            ClearTopMostWindows();
         }
 
         private static bool? IsElevatedValue;
@@ -270,7 +272,7 @@ namespace TopMostFriend {
                         if(Settings.Get(SHIFT_CLICK_BLACKLIST, true) && Control.ModifierKeys.HasFlag(Keys.Shift)) {
                             AddBlacklistedTitle(title);
                             SaveBlacklistedTitles();
-                        } else if(!window.ToggleTopMost())
+                        } else if(!window.ToggleTopMost(true))
                             TopMostFailed(window);
                     })) {
                         CheckOnClick = true,
@@ -285,6 +287,17 @@ namespace TopMostFriend {
 
             CtxMenu.Items.Clear();
             CtxMenu.Items.AddRange(items.ToArray());
+        }
+
+        private static void ClearTopMostWindows()
+        {
+            IEnumerable<WindowInfo> windows = WindowInfo.GetAllWindows();
+            foreach(WindowInfo window in windows) {
+                    if (window.IsTopMost)
+                    {
+                        window.ToggleTopMost(false);
+                    }
+            }
         }
 
         private static void TopMostFailed(WindowInfo window) {
@@ -339,7 +352,7 @@ namespace TopMostFriend {
         public static void ToggleForegroundWindow() {
             WindowInfo window = WindowInfo.GetForegroundWindow();
 
-            if(window.ToggleTopMost()) {
+            if(window.ToggleTopMost(true)) {
                 if(Settings.Get(TOGGLE_BALLOON_SETTING, false)) {
                     string title = window.Title;
                     SysIcon?.ShowBalloonTip(
@@ -375,5 +388,6 @@ namespace TopMostFriend {
             if((e.Button & MouseButtons.Right) > 0)
                 RefreshWindowList();
         }
+
     }
 }

--- a/TopMostFriend/WindowInfo.cs
+++ b/TopMostFriend/WindowInfo.cs
@@ -67,11 +67,11 @@ namespace TopMostFriend {
             Win32.SwitchToThisWindow(Handle, false);
         }
 
-        public bool ToggleTopMost() {
+        public bool ToggleTopMost(bool switchWindow) {
             bool expected = !IsTopMost;
             IsTopMost = expected;
             bool success = IsTopMost == expected;
-            if(expected && success)
+            if(expected && success && switchWindow)
                 SwitchTo();
             return success;
         }


### PR DESCRIPTION
I opened an issue here https://github.com/flashwave/topmostfriend/issues/1#issue-902790902

In this pull request I added some code to run before the end of the program which cycles through the opened windows, checks if any of those are pinned on top and unpins them.

I have also edited a previous method adding a boolean value in order to preserve its original usage when used outside of my new code. (to switch window after calling ToggleTopMost method)